### PR TITLE
Add ruff-based code checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -689,3 +689,14 @@ Zusatz
 1. **GCD-Normalisierung**: Nach dem Brüche-Beseitigen teile ich `A·x + B = 0` immer durch `gcd(|A|,|B|)`, damit alle sichtbaren Zahlen klein bleiben (und ≤ 120).
 
 3. **Fehlschläge**: Wenn nach **max. 200 Resamples** die Grenzen nicht einhaltbar sind, **überspringe** ich die Aufgabe und generiere neu, bis die Zielanzahl erreicht ist.
+
+## Entwicklungsrichtlinien
+
+Nach jeder Änderung am Code müssen die folgenden Prüfungen erfolgreich
+durchlaufen werden:
+
+```bash
+python -m ruff format --check .
+python -m ruff check .
+pytest
+```

--- a/gleichungs_generator.py
+++ b/gleichungs_generator.py
@@ -6,6 +6,7 @@ Die Implementierung erzeugt zufällige Aufgaben der Level L1–L5 und
 speichert sie als Arbeits- und Lösungsblatt im DOCX‑Format.  Sie folgt
 den Vorgaben aus AGENTS.md in kompakter Form.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -185,9 +186,10 @@ def build_L4(rng: random.Random, sol: Fraction, cfg: Dict) -> Equation:
     u = (a * (m * sol + n) + b - (c * sol + d) - (p - (q * sol + r))) / s - t * sol
     lhs = a * (m * x + n) + b - (c * x + d)
     rhs = p - (q * x + r) + s * (t * x + u)
-    text = f"{a}({m}x + {n}) + {b} - ({c}x + {d}) = {p} - ({q}x + {r}) + {s}({t}x + {u})"
+    text = (
+        f"{a}({m}x + {n}) + {b} - ({c}x + {d}) = {p} - ({q}x + {r}) + {s}({t}x + {u})"
+    )
     return Equation("L4", sp.Eq(lhs, rhs, evaluate=False), text, sol)
-
 
 
 def build_L5(rng: random.Random, sol: Fraction, cfg: Dict) -> Equation:
@@ -205,7 +207,11 @@ def build_L5(rng: random.Random, sol: Fraction, cfg: Dict) -> Equation:
             if b.denominator != 1 or c * sol + d == 0:
                 continue
             lhs = (a * x + int(b)) / (c * x + d)
-            rhs = sp.Integer(k) if k.denominator == 1 else sp.Rational(k.numerator, k.denominator)
+            rhs = (
+                sp.Integer(k)
+                if k.denominator == 1
+                else sp.Rational(k.numerator, k.denominator)
+            )
             text = f"({a}x + {int(b)})/({c}x + {d}) = {nice_frac(k)}"
             excluded = {Fraction(-d, c)}
             return Equation("L5", sp.Eq(lhs, rhs, evaluate=False), text, sol, excluded)
@@ -218,11 +224,11 @@ def build_L5(rng: random.Random, sol: Fraction, cfg: Dict) -> Equation:
             d2 = rng.randint(mn, mx)
             b2 = rng.randint(mn, mx)
             num = (a2 * sol + b2) * (c1 * sol + d1)
-            den = (c2 * sol + d2)
+            den = c2 * sol + d2
             if den == 0 or c1 * sol + d1 == 0:
                 continue
             b1 = num / den - a1 * sol
-            if isinstance(b1, Fraction) or getattr(b1, 'denominator', 1) != 1:
+            if isinstance(b1, Fraction) or getattr(b1, "denominator", 1) != 1:
                 b1 = Fraction(b1).limit_denominator()
             if b1.denominator != 1:
                 continue
@@ -231,6 +237,8 @@ def build_L5(rng: random.Random, sol: Fraction, cfg: Dict) -> Equation:
             text = f"({a1}x + {int(b1)})/({c1}x + {d1}) = ({a2}x + {b2})/({c2}x + {d2})"
             excluded = {Fraction(-d1, c1), Fraction(-d2, c2)}
             return Equation("L5", sp.Eq(lhs, rhs, evaluate=False), text, sol, excluded)
+
+
 BUILDERS = {
     "L1": build_L1,
     "L2": build_L2,
@@ -244,7 +252,6 @@ BUILDERS = {
 # ---------------------------------------------------------------------------
 
 
-
 def validate(eq: Equation) -> bool:
     if not isinstance(eq.sympy_eq, sp.Equality):
         return False
@@ -256,9 +263,10 @@ def validate(eq: Equation) -> bool:
         return False
     if sp.simplify(sol_list[0] - eq.solution) != 0:
         return False
-    if any(sp.simplify(eq.sympy_eq.subs(x, ex)) == True for ex in eq.excluded):
+    if any(bool(sp.simplify(eq.sympy_eq.subs(x, ex))) for ex in eq.excluded):
         return False
     return True
+
 
 def canonical_key(eq: Equation) -> str:
     expr = sp.together(eq.sympy_eq.lhs - eq.sympy_eq.rhs)
@@ -288,7 +296,9 @@ def solve_steps(eq: Equation, cfg: Dict) -> List[str]:
     if lcm != 1:
         lhs = sp.simplify(lhs * lcm)
         rhs = sp.simplify(rhs * lcm)
-        steps.append(f"Mit {expr_to_str(lcm)} multiplizieren: {expr_to_str(lhs)} = {expr_to_str(rhs)}")
+        steps.append(
+            f"Mit {expr_to_str(lcm)} multiplizieren: {expr_to_str(lhs)} = {expr_to_str(rhs)}"
+        )
     expr = sp.expand(lhs - rhs)
     steps.append(f"Alle Terme auf eine Seite: {expr_to_str(expr)} = 0")
     poly = sp.Poly(expr, x)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ dependencies = [
 
 [project.scripts]
 gleichungen = "gleichungs_generator:main"
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+extend-exclude = ["examples"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-docx~=1.1
 sympy~=1.12
+ruff>=0.0.272

--- a/tests/test_l1_solution.py
+++ b/tests/test_l1_solution.py
@@ -1,5 +1,4 @@
 import random
-from fractions import Fraction
 import sympy as sp
 import sys
 from pathlib import Path

--- a/tests/test_ruff.py
+++ b/tests/test_ruff.py
@@ -1,0 +1,25 @@
+"""Ensure code base passes ruff checks and formatting."""
+
+from __future__ import annotations
+
+import subprocess
+
+
+def test_ruff_check() -> None:
+    """ruff should report no lint errors."""
+    result = subprocess.run(
+        ["python", "-m", "ruff", "check", "."],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ruff_format() -> None:
+    """ruff should report no formatting changes."""
+    result = subprocess.run(
+        ["python", "-m", "ruff", "format", "--check", "."],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- configure ruff via `pyproject.toml` and depend on it
- add tests ensuring ruff lint and formatting checks run cleanly
- document required `ruff` and `pytest` checks in AGENTS guidelines

## Testing
- `python -m ruff format --check .`
- `python -m ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c31875783883279a2e44d30d5c2e19