### PR TITLE
Add numeric limit enforcement for equation generation

### DIFF
--- a/tests/test_numeric_limits.py
+++ b/tests/test_numeric_limits.py
@@ -1,0 +1,23 @@
+import sympy as sp
+from fractions import Fraction
+
+from gleichungs_generator import Equation, numeric_limits_ok, x
+
+
+def make_eq(lhs, rhs, sol=Fraction(0)):
+    return Equation("T", sp.Eq(lhs, rhs, evaluate=False), "", sol)
+
+
+def test_numeric_limits_ok_pass():
+    eq = make_eq(sp.Rational(1, 3) * x, sp.Rational(2, 5), Fraction(10, 3))
+    assert numeric_limits_ok(eq)
+
+
+def test_numeric_limits_lcm_fail():
+    eq = make_eq(sp.Rational(1, 121) * x, 0, Fraction(0))
+    assert not numeric_limits_ok(eq)
+
+
+def test_numeric_limits_coeff_fail():
+    eq = make_eq(121 * x + 1, 0, Fraction(-1, 121))
+    assert not numeric_limits_ok(eq)


### PR DESCRIPTION
## Summary
- enforce numeric safety limits (|value| ≤ 120) across generation and solving steps
- normalize coefficients with gcd after clearing denominators
- retry equation generation up to 200 times when limits are exceeded
- add unit tests for numeric limit validation

## Testing
- `python -m ruff format .`
- `python -m ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c31c00b07083279c1492e55971e811