### PR TITLE
chore: add CI pipeline with coverage diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Ruff format and lint
+        run: |
+          python -m ruff format --check .
+          python -m ruff check .
+      - name: Run tests with coverage
+        run: |
+          pytest --testmon --cov=. --cov-report=xml
+      - name: Diff coverage
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
+          diff-cover coverage.xml --compare-branch origin/${{ github.event.pull_request.base.ref }} --fail-under=90

--- a/README.md
+++ b/README.md
@@ -139,16 +139,19 @@ DEFAULT_CONFIG = {
 ## Tests
 
 ```bash
-# Alle Tests ausführen
-pytest
+# Alle Tests mit Coverage ausführen (selektiv via testmon)
+pytest --testmon --cov=. --cov-report=xml
+
+# Diff-Coverage (geänderte Zeilen ≥90 %)
+diff-cover coverage.xml --compare-branch origin/main --fail-under=90
 
 # Einzelne Tests
 pytest test_numeric_limits.py
 pytest test_l1_solution.py
 
 # Code-Qualität prüfen
-python -m ruff check .
 python -m ruff format --check .
+python -m ruff check .
 ```
 
 ## Dateien

--- a/app.py
+++ b/app.py
@@ -6,11 +6,10 @@ import json
 import math
 from io import BytesIO
 from pathlib import Path
-from typing import List
 
 import streamlit as st
-from PIL import Image, ImageDraw, ImageFont
 import sympy as sp
+from PIL import Image, ImageDraw, ImageFont
 
 from gleichungs_generator import (
     DEFAULT_CONFIG,
@@ -35,7 +34,7 @@ def lcm_leq_limit(eq: Equation, limit: int = MAX_ABS) -> tuple[bool, int]:
     """Prüft ob kgV aller Nenner ≤ limit ist."""
     expr = eq.sympy_eq.lhs - eq.sympy_eq.rhs
     expr_together = sp.together(expr)
-    denominators: List[int] = []
+    denominators: list[int] = []
     for term in sp.Add.make_args(expr_together):
         _, denom = sp.fraction(term)
         if denom != 1:
@@ -261,7 +260,7 @@ if page == "Einstellungen":
 
 if page == "Vorschau":
     st.title("Vorschau")
-    problems: List[Problem] = st.session_state.get("problems", [])
+    problems: list[Problem] = st.session_state.get("problems", [])
     if not problems:
         st.info("Keine Aufgaben generiert.")
     else:
@@ -281,7 +280,8 @@ if page == "Vorschau":
         for p in problems:
             dops_counter.update(p.dops)
         st.info(
-            f"Akzeptiert: {total} | Ø Resamples: {avg_res:.2f} | D-OPS: {dict(dops_counter)}"
+            f"Akzeptiert: {total} | Ø Resamples: {avg_res:.2f} | "
+            f"D-OPS: {dict(dops_counter)}"
         )
         for i, prob in enumerate(problems, 1):
             st.subheader(f"Aufgabe {i}")
@@ -303,9 +303,12 @@ if page == "Vorschau":
                 st.caption(f"Resamples: {prob.resamples}")
             if st.checkbox("Lösungsschritte anzeigen", key=f"steps_{i}"):
                 for step in prob.steps:
-                    st.write(
-                        f"- {step.description_de}: {beautify_equation(step.lhs, step.rhs, st.session_state['config']['visual_complexity'])}"
+                    equation = beautify_equation(
+                        step.lhs,
+                        step.rhs,
+                        st.session_state["config"]["visual_complexity"],
                     )
+                    st.write(f"- {step.description_de}: {equation}")
 
 # ---------------------------------------------------------------------------
 # Export
@@ -313,7 +316,7 @@ if page == "Vorschau":
 
 if page == "Export":
     st.title("Export")
-    problems: List[Problem] = st.session_state.get("problems", [])
+    problems: list[Problem] = st.session_state.get("problems", [])
     cfg = st.session_state.get("config", {})
     if not problems:
         st.info("Keine Aufgaben zum Export.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ gleichungen = "gleichungs_generator:main"
 line-length = 88
 target-version = "py310"
 extend-exclude = ["examples"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,9 @@ python-docx~=1.1
 sympy~=1.12
 ruff>=0.0.272
 pytest>=7.0.0
+pytest-cov>=4.0.0
+pytest-testmon>=2.0.0
+diff-cover>=7.0.0
+coverage>=7.0.0
 streamlit
 pillow

--- a/tests/test_generate_equations.py
+++ b/tests/test_generate_equations.py
@@ -1,0 +1,31 @@
+import random
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from gleichungs_generator import (
+    DEFAULT_CONFIG,
+    build_L4,
+    generate_equations,
+    sample_solution,
+    solve_steps,
+)
+
+
+def test_build_L4_mixed_format_and_steps():
+    rng = random.Random(0)
+    sol = sample_solution(rng, DEFAULT_CONFIG)
+    eq = build_L4(rng, sol, DEFAULT_CONFIG)
+    assert "*" not in eq.text
+    steps = solve_steps(eq, DEFAULT_CONFIG)
+    assert steps[0].description_de == "Ausgangsgleichung"
+
+
+def test_generate_equations_all_levels():
+    cfg = DEFAULT_CONFIG.copy()
+    cfg["seed"] = 0
+    cfg["counts"] = {"L1": 1, "L2": 1, "L3": 1, "L4": 1, "L5": 1}
+    problems = generate_equations(cfg)
+    assert len(problems) == 5
+    assert {p.equation.level for p in problems} == {"L1", "L2", "L3", "L4", "L5"}

--- a/tests/test_l1_solution.py
+++ b/tests/test_l1_solution.py
@@ -1,10 +1,11 @@
 import random
-import sympy as sp
 import sys
 from pathlib import Path
 
+import sympy as sp
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from gleichungs_generator import build_L1, DEFAULT_CONFIG, x, sample_solution
+from gleichungs_generator import DEFAULT_CONFIG, build_L1, sample_solution, x
 
 
 def test_build_L1_solution():

--- a/tests/test_numeric_limits.py
+++ b/tests/test_numeric_limits.py
@@ -1,5 +1,6 @@
-import sympy as sp
 from fractions import Fraction
+
+import sympy as sp
 
 from gleichungs_generator import Equation, numeric_limits_ok, x
 
@@ -26,3 +27,18 @@ def test_numeric_limits_coeff_fail():
 def test_numeric_limits_symbolic_denominator():
     eq = make_eq(1 / (x + 2), 0, Fraction(0))
     assert numeric_limits_ok(eq)
+
+
+def test_numeric_limits_rational_denominator():
+    eq = make_eq(1 / (sp.Rational(2, 3) * (x + 1)), 0)
+    assert numeric_limits_ok(eq)
+
+
+def test_numeric_limits_non_integer_constant():
+    eq = make_eq(1 / sp.pi, 0)
+    assert numeric_limits_ok(eq)
+
+
+def test_numeric_limits_constant_fail():
+    eq = make_eq(60, -70)
+    assert not numeric_limits_ok(eq)


### PR DESCRIPTION
## Summary
- run Ruff formatting, lint, and tests with coverage in CI
- enforce 90% diff coverage on pull requests
- document coverage workflow and install needed tooling
- add tests exercising equation generation and mixed-format Level 4 cases to satisfy coverage
- cover numeric limit edge cases with rational and non-integer denominators to raise diff coverage

## Testing
- `python -m ruff format --check .`
- `python -m ruff check .`
- `pytest`
- `python -m coverage run -m pytest`
- `diff-cover coverage.xml --compare-branch=HEAD~2`


------
https://chatgpt.com/codex/tasks/task_e_68c5c2bb4f3883278e5299ded4e63dbf