### PR TITLE
Refine numeric validation and improve solver robustness

### DIFF
--- a/tests/test_generate_equations.py
+++ b/tests/test_generate_equations.py
@@ -1,15 +1,22 @@
 import random
 import sys
+from fractions import Fraction
 from pathlib import Path
+
+import sympy as sp
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from gleichungs_generator import (
+from gleichungs_generator import (  # noqa: E402
     DEFAULT_CONFIG,
+    Equation,
     build_L4,
+    fraction_to_mixed,
     generate_equations,
+    numeric_limits_ok,
     sample_solution,
     solve_steps,
+    x,
 )
 
 
@@ -29,3 +36,23 @@ def test_generate_equations_all_levels():
     problems = generate_equations(cfg)
     assert len(problems) == 5
     assert {p.equation.level for p in problems} == {"L1", "L2", "L3", "L4", "L5"}
+
+
+def test_fraction_to_mixed_handles_negative_values():
+    assert fraction_to_mixed(Fraction(-5, 3)) == "-1 2/3"
+    assert fraction_to_mixed(Fraction(-4, 2)) == "-2"
+
+
+def test_solve_steps_handles_symbolic_denominator():
+    eq = Equation(
+        level="L5",
+        sympy_eq=sp.Eq((2 * x + 3) / (3 * x + 5), sp.Rational(7, 11)),
+        text="",
+        solution=Fraction(2, 1),
+        excluded={Fraction(-5, 3)},
+    )
+
+    assert numeric_limits_ok(eq)
+    steps = solve_steps(eq, DEFAULT_CONFIG)
+    assert any("Hauptnenner" in step.description_de for step in steps)
+    assert steps[-1].rhs == sp.Integer(2)


### PR DESCRIPTION
## Summary
- fix mixed-number conversion and SymPy text formatting to avoid incorrect negatives and stray multipliers
- harden numeric limit validation and solver steps for equations with symbolic denominators and exact rationals
- restructure generation loop to enforce quotas and add regression tests for negative fractions and symbolic denominators

## Testing
- python -m ruff format --check .
- python -m ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef42da2488327bd93705dba765762